### PR TITLE
Refactor, Remove tenant id params on domain service functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,6 @@ curl --location --request GET 'http://localhost:3000/api/v1/bags/BagT:7a635074-c
 
 - [x] Develop a API key based access for the API calls
 - [x] Develop a CoreOS access token based access for the API calls
-- [ ] CoreOS domain api calls to use request ID sent from `X-COREOS-REQUEST-ID` headers
-- [ ] CoreOS domain api calls to use user info from the access token sent on `X-COREOS-ACCESS` headers
-- [ ] Developer a context based utility to pass tenant id and user info to domain api calls instead of tenant id/ user info function parameter in the services
+- [x] CoreOS domain api calls to use request ID sent from `X-COREOS-REQUEST-ID` headers
+- [x] CoreOS domain api calls to use user info from the access token sent on `X-COREOS-ACCESS` headers
+- [x] Developer a context based utility to pass tenant id and user info to domain api calls instead of tenant id/ user info function parameter in the services

--- a/api/server.v1.go
+++ b/api/server.v1.go
@@ -2,7 +2,9 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -21,11 +23,21 @@ func NewServerV1() ServerV1 {
 	}
 }
 
+func prepareContext(c *gin.Context) context.Context {
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, common.ContextTenantId, c.GetString(common.ContextTenantId))
+	ctx = context.WithValue(ctx, common.ContextRequestID, c.GetString(common.ContextRequestID))
+	ctx = context.WithValue(ctx, common.ContextUserinfo, fmt.Sprintf("%#v", c.MustGet(common.ContextUserinfo)))
+	ctx = context.WithValue(ctx, common.ContextMiddlewareAccessToken, c.GetString(common.ContextMiddlewareAccessToken))
+	return ctx
+}
+
 // Init
 
 func (s ServerV1) InitTenant(c *gin.Context, params api_v1.InitTenantParams) {
+	ctx := prepareContext(c)
 	Response := &api_v1.DefaultResponse{}
-	e := s.ser.Init(params.XCOREOSTENANTID)
+	e := s.ser.Init(ctx)
 	if e != nil {
 		Response.Error = &api_v1.ErrorSchema{}
 		Response.Error.Description = e.Error()
@@ -38,8 +50,8 @@ func (s ServerV1) InitTenant(c *gin.Context, params api_v1.InitTenantParams) {
 // Packages
 
 func (s ServerV1) GetPackage(c *gin.Context, packageId string, params api_v1.GetPackageParams) {
-
-	r, e := s.ser.GetPackage(params.XCOREOSTENANTID, packageId)
+	ctx := prepareContext(c)
+	r, e := s.ser.GetPackage(ctx, packageId)
 	if e != nil {
 		Response := &api_v1.CreatedResponse{}
 		Response.Error = &api_v1.ErrorSchema{}
@@ -52,8 +64,8 @@ func (s ServerV1) GetPackage(c *gin.Context, packageId string, params api_v1.Get
 }
 
 func (s ServerV1) GetPackages(c *gin.Context, params api_v1.GetPackagesParams) {
-
-	r, e := s.ser.GetPackages(params.XCOREOSTENANTID)
+	ctx := prepareContext(c)
+	r, e := s.ser.GetPackages(ctx)
 	if e != nil {
 		Response := &api_v1.CreatedResponse{}
 		Response.Error = &api_v1.ErrorSchema{}
@@ -66,13 +78,13 @@ func (s ServerV1) GetPackages(c *gin.Context, params api_v1.GetPackagesParams) {
 }
 
 func (s ServerV1) CreatePackage(c *gin.Context, params api_v1.CreatePackageParams) {
+	ctx := prepareContext(c)
 	Response := &api_v1.CreatedResponse{}
-
 	r := api_v1.CreatePackageJSONRequestBody{}
 	buf := new(bytes.Buffer)
 	buf.ReadFrom(c.Request.Body)
 	json.Unmarshal([]byte(buf.String()), &r)
-	id, e := s.ser.CreatePackage(params.XCOREOSTENANTID, r)
+	id, e := s.ser.CreatePackage(ctx, r)
 	if e != nil {
 		Response.Error = &api_v1.ErrorSchema{}
 		Response.Error.Description = e.Error()
@@ -86,9 +98,9 @@ func (s ServerV1) CreatePackage(c *gin.Context, params api_v1.CreatePackageParam
 }
 
 func (s ServerV1) ChangePackageState(c *gin.Context, packageId string, command string, params api_v1.ChangePackageStateParams) {
+	ctx := prepareContext(c)
 	Response := &api_v1.CreatedResponse{}
-
-	e := s.ser.UpdateContainerState(params.XCOREOSTENANTID, packageId, command, common.PackageContainerTypeName)
+	e := s.ser.UpdateContainerState(ctx, packageId, command, common.PackageContainerTypeName)
 	if e != nil {
 		Response.Error = &api_v1.ErrorSchema{}
 		Response.Error.Description = e.Error()
@@ -102,8 +114,8 @@ func (s ServerV1) ChangePackageState(c *gin.Context, packageId string, command s
 // Bags
 
 func (s ServerV1) GetBag(c *gin.Context, bagId string, params api_v1.GetBagParams) {
-
-	r, e := s.ser.GetBag(params.XCOREOSTENANTID, bagId)
+	ctx := prepareContext(c)
+	r, e := s.ser.GetBag(ctx, bagId)
 	if e != nil {
 		Response := &api_v1.CreatedResponse{}
 		Response.Error = &api_v1.ErrorSchema{}
@@ -117,8 +129,8 @@ func (s ServerV1) GetBag(c *gin.Context, bagId string, params api_v1.GetBagParam
 }
 
 func (s ServerV1) GetBags(c *gin.Context, params api_v1.GetBagsParams) {
-
-	r, e := s.ser.GetBags(params.XCOREOSTENANTID)
+	ctx := prepareContext(c)
+	r, e := s.ser.GetBags(ctx)
 	if e != nil {
 		Response := &api_v1.CreatedResponse{}
 		Response.Error = &api_v1.ErrorSchema{}
@@ -132,13 +144,13 @@ func (s ServerV1) GetBags(c *gin.Context, params api_v1.GetBagsParams) {
 }
 
 func (s ServerV1) CreateBag(c *gin.Context, params api_v1.CreateBagParams) {
+	ctx := prepareContext(c)
 	Response := &api_v1.CreatedResponse{}
-
 	r := api_v1.CreateBagJSONRequestBody{}
 	buf := new(bytes.Buffer)
 	buf.ReadFrom(c.Request.Body)
 	json.Unmarshal([]byte(buf.String()), &r)
-	id, e := s.ser.CreateBag(params.XCOREOSTENANTID, r)
+	id, e := s.ser.CreateBag(ctx, r)
 	if e != nil {
 		Response.Error = &api_v1.ErrorSchema{}
 		Response.Error.Description = e.Error()
@@ -153,8 +165,9 @@ func (s ServerV1) CreateBag(c *gin.Context, params api_v1.CreateBagParams) {
 }
 
 func (s ServerV1) ChangeBagState(c *gin.Context, bagId string, command string, params api_v1.ChangeBagStateParams) {
+	ctx := prepareContext(c)
 	Response := &api_v1.DefaultResponse{}
-	e := s.ser.UpdateContainerState(params.XCOREOSTENANTID, bagId, command, common.BagContainerTypeName)
+	e := s.ser.UpdateContainerState(ctx, bagId, command, common.BagContainerTypeName)
 	if e != nil {
 		Response.Error = &api_v1.ErrorSchema{}
 		Response.Error.Description = e.Error()
@@ -166,8 +179,9 @@ func (s ServerV1) ChangeBagState(c *gin.Context, bagId string, command string, p
 }
 
 func (s ServerV1) AddPackageToBag(c *gin.Context, bagId string, packageId string, params api_v1.AddPackageToBagParams) {
+	ctx := prepareContext(c)
 	Response := &api_v1.DefaultResponse{}
-	e := s.ser.ContainerizeOperations(params.XCOREOSTENANTID, bagId, packageId, common.CONTAINER_OPERATION_CONTAINERIZE)
+	e := s.ser.ContainerizeOperations(ctx, bagId, packageId, common.CONTAINER_OPERATION_CONTAINERIZE)
 	if e != nil {
 		Response.Error = e
 		c.JSON(http.StatusInternalServerError, Response)
@@ -178,8 +192,9 @@ func (s ServerV1) AddPackageToBag(c *gin.Context, bagId string, packageId string
 }
 
 func (s ServerV1) RemovePackageFromBag(c *gin.Context, bagId string, packageId string, params api_v1.RemovePackageFromBagParams) {
+	ctx := prepareContext(c)
 	Response := &api_v1.DefaultResponse{}
-	e := s.ser.ContainerizeOperations(params.XCOREOSTENANTID, bagId, packageId, common.CONTAINER_OPERATION_DECONTAINERIZE)
+	e := s.ser.ContainerizeOperations(ctx, bagId, packageId, common.CONTAINER_OPERATION_DECONTAINERIZE)
 	if e != nil {
 		Response.Error = e
 		c.JSON(http.StatusInternalServerError, Response)

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -41,6 +41,7 @@ func main() {
 	r.Use(gin.Recovery())
 	r.Use(api.CORS())
 	r.Use(api.Authorize)
+	r.Use(api.ContextMiddlewareToken)
 
 	r.GET("/health", func(c *gin.Context) {
 		c.JSON(200, gin.H{"message": "ok"})

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 
 require (
 	github.com/goccy/go-json v0.10.0 // indirect
+	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,7 @@ github.com/goccy/go-json v0.9.7/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGF
 github.com/goccy/go-json v0.9.11/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/goccy/go-json v0.10.0 h1:mXKd9Qw4NuzShiRlOXKews24ufknHO7gx30lsDyokKA=
 github.com/goccy/go-json v0.10.0/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang/glog v1.0.0 h1:nfP3RFugxnNRyKgeWd4oI1nYvXpxrx8ck8ZrcizshdQ=
 github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=

--- a/init/init.go
+++ b/init/init.go
@@ -21,22 +21,22 @@ func getErrorResponse(inputBuff *io.ReadCloser) containerdomain.ErrorResponse {
 	return r
 }
 
-func Initialize(tenantId string) error {
+func Initialize(ctx context.Context, tenantId string) error {
 
 	glog.Info("Initializing the application with container types")
 
 	containerClient := domain.NewContainerClient(tenantId)
-	ctx := context.Background()
-
-	token, _ := domain.GetToken(tenantId)
+	requestId := ctx.Value(common.ContextRequestID).(string)
+	token := ctx.Value(common.ContextMiddlewareAccessToken).(string)
+	userinfo := ctx.Value(common.ContextUserinfo).(string)
 
 	// Package type
 
-	getContainerTypeRequest1 := containerClient.ContainerTypeApi.GetContainerTypeById(ctx, common.PackageContainerTypeName)
-	getContainerTypeRequest1 = getContainerTypeRequest1.XCOREOSACCESS(token)
-	getContainerTypeRequest1 = getContainerTypeRequest1.XCOREOSTID(tenantId)
-	getContainerTypeRequest1 = getContainerTypeRequest1.XCOREOSREQUESTID(common.UUIDv4())
-	getContainerTypeRequest1 = getContainerTypeRequest1.XCOREOSUSERINFO("1234")
+	getContainerTypeRequest1 := containerClient.ContainerTypeApi.GetContainerTypeById(ctx, common.PackageContainerTypeName).
+		XCOREOSACCESS(token).
+		XCOREOSTID(tenantId).
+		XCOREOSREQUESTID(requestId).
+		XCOREOSUSERINFO(userinfo)
 
 	_, getresponse1, _ := containerClient.ContainerTypeApi.GetContainerTypeByIdExecute(getContainerTypeRequest1)
 
@@ -45,11 +45,11 @@ func Initialize(tenantId string) error {
 		// The container type you are searching/updating undefined doesnt exists
 		if getErrResponse.Error.Code == "100920043304" {
 			// create container type PackageCsa
-			containerTypeRequest := containerClient.ContainerTypeApi.CreateContainerType(ctx)
-			containerTypeRequest = containerTypeRequest.XCOREOSACCESS(token)
-			containerTypeRequest = containerTypeRequest.XCOREOSTID(tenantId)
-			containerTypeRequest = containerTypeRequest.XCOREOSREQUESTID(common.UUIDv4())
-			containerTypeRequest = containerTypeRequest.XCOREOSUSERINFO("1234")
+			containerTypeRequest := containerClient.ContainerTypeApi.CreateContainerType(ctx).
+				XCOREOSACCESS(token).
+				XCOREOSTID(tenantId).
+				XCOREOSREQUESTID(requestId).
+				XCOREOSUSERINFO("1234")
 
 			PackageCsaContainerTypeCreateRequest := containerdomain.ContainerTypeCreateRequest{
 				Name:   common.PackageContainerTypeName,
@@ -75,12 +75,12 @@ func Initialize(tenantId string) error {
 	glog.Info("====================PackageCsa Type Created Idempotently=====================")
 
 	glog.Info("====================Create PackageCsa Type attributes=====================")
-	ApiUpdateAttributesConfigRequest := containerClient.ContainerTypeAttributesConfigApi.UpdateAttributesConfig(ctx, common.PackageContainerTypeName)
-	ApiUpdateAttributesConfigRequest = ApiUpdateAttributesConfigRequest.XCOREOSACCESS(token)
-	ApiUpdateAttributesConfigRequest = ApiUpdateAttributesConfigRequest.XCOREOSORIGINTOKEN(token)
-	ApiUpdateAttributesConfigRequest = ApiUpdateAttributesConfigRequest.XCOREOSTID(tenantId)
-	ApiUpdateAttributesConfigRequest = ApiUpdateAttributesConfigRequest.XCOREOSREQUESTID(common.UUIDv4())
-	ApiUpdateAttributesConfigRequest = ApiUpdateAttributesConfigRequest.XCOREOSUSERINFO("1234")
+	ApiUpdateAttributesConfigRequest := containerClient.ContainerTypeAttributesConfigApi.UpdateAttributesConfig(ctx, common.PackageContainerTypeName).
+		XCOREOSACCESS(token).
+		XCOREOSORIGINTOKEN(token).
+		XCOREOSTID(tenantId).
+		XCOREOSREQUESTID(requestId).
+		XCOREOSUSERINFO(userinfo)
 
 	attributesConfigUpdateRequest := containerdomain.AttributesConfigUpdateRequest{
 		Attributes: []containerdomain.AttributeConfig{
@@ -209,11 +209,11 @@ func Initialize(tenantId string) error {
 
 	// Bag type
 
-	getContainerTypeRequest2 := containerClient.ContainerTypeApi.GetContainerTypeById(ctx, common.BagContainerTypeName)
-	getContainerTypeRequest2 = getContainerTypeRequest2.XCOREOSACCESS(token)
-	getContainerTypeRequest2 = getContainerTypeRequest2.XCOREOSTID(tenantId)
-	getContainerTypeRequest2 = getContainerTypeRequest2.XCOREOSREQUESTID(common.UUIDv4())
-	getContainerTypeRequest2 = getContainerTypeRequest2.XCOREOSUSERINFO("1234")
+	getContainerTypeRequest2 := containerClient.ContainerTypeApi.GetContainerTypeById(ctx, common.BagContainerTypeName).
+		XCOREOSACCESS(token).
+		XCOREOSTID(tenantId).
+		XCOREOSREQUESTID(requestId).
+		XCOREOSUSERINFO(userinfo)
 
 	_, getresponse2, _ := containerClient.ContainerTypeApi.GetContainerTypeByIdExecute(getContainerTypeRequest2)
 
@@ -221,11 +221,11 @@ func Initialize(tenantId string) error {
 		errResponse := getErrorResponse(&getresponse2.Body)
 		if errResponse.Error.Description == "The container type you are searching/updating undefined doesnt exists" {
 			// create container type BagCsa
-			containerTypeRequest := containerClient.ContainerTypeApi.CreateContainerType(ctx)
-			containerTypeRequest = containerTypeRequest.XCOREOSACCESS(token)
-			containerTypeRequest = containerTypeRequest.XCOREOSTID(tenantId)
-			containerTypeRequest = containerTypeRequest.XCOREOSREQUESTID(common.UUIDv4())
-			containerTypeRequest = containerTypeRequest.XCOREOSUSERINFO("1234")
+			containerTypeRequest := containerClient.ContainerTypeApi.CreateContainerType(ctx).
+				XCOREOSACCESS(token).
+				XCOREOSTID(tenantId).
+				XCOREOSREQUESTID(requestId).
+				XCOREOSUSERINFO(userinfo)
 
 			BagContainerTypeCreateRequest := containerdomain.ContainerTypeCreateRequest{
 				Name:   common.BagContainerTypeName,
@@ -257,7 +257,7 @@ func Initialize(tenantId string) error {
 	ApiUpdateAttributesConfigRequest = ApiUpdateAttributesConfigRequest.XCOREOSACCESS(token)
 	ApiUpdateAttributesConfigRequest = ApiUpdateAttributesConfigRequest.XCOREOSORIGINTOKEN(token)
 	ApiUpdateAttributesConfigRequest = ApiUpdateAttributesConfigRequest.XCOREOSTID(tenantId)
-	ApiUpdateAttributesConfigRequest = ApiUpdateAttributesConfigRequest.XCOREOSREQUESTID(common.UUIDv4())
+	ApiUpdateAttributesConfigRequest = ApiUpdateAttributesConfigRequest.XCOREOSREQUESTID(requestId)
 	ApiUpdateAttributesConfigRequest = ApiUpdateAttributesConfigRequest.XCOREOSUSERINFO("1234")
 
 	attributesConfigUpdateRequest = containerdomain.AttributesConfigUpdateRequest{

--- a/internal/pkg/common/constants.go
+++ b/internal/pkg/common/constants.go
@@ -14,6 +14,10 @@ const (
 	BagContainerTypeName               = "BagT"
 	CONTAINER_OPERATION_CONTAINERIZE   = "CONTAINERIZE"
 	CONTAINER_OPERATION_DECONTAINERIZE = "DECONTAINERIZE"
+	ContextTenantId                    = "tenantId"
+	ContextUserinfo                    = "userinfo"
+	ContextRequestID                   = "requestId"
+	ContextMiddlewareAccessToken       = "middlewareAccessToken"
 )
 
 type ContainerStateOperation struct {

--- a/internal/pkg/service/service.go
+++ b/internal/pkg/service/service.go
@@ -43,23 +43,26 @@ func getErrorResponse(inputBuff *io.ReadCloser) *containerdomain.ErrorResponse {
 	return &r
 }
 
-func (s Service) Init(tenantId string) error {
-	e := inits.Initialize(tenantId)
+func (s Service) Init(ctx context.Context) error {
+	e := inits.Initialize(ctx, ctx.Value(common.ContextTenantId).(string))
 	if e != nil {
 		return e
 	}
 	return nil
 }
 
-func (s Service) GetPackage(tenantId string, packageId string) (*api_v1.GetPackageResponse, error) {
-	token, _ := domain.GetToken(tenantId)
-	ctx := context.Background()
+func (s Service) GetPackage(ctx context.Context, packageId string) (*api_v1.GetPackageResponse, error) {
+	tenantId := ctx.Value(common.ContextTenantId).(string)
+	token := ctx.Value(common.ContextMiddlewareAccessToken).(string)
+	requestId := ctx.Value(common.ContextRequestID).(string)
+	userinfo := ctx.Value(common.ContextUserinfo).(string)
+
 	ApiGetContainerByIdRequest := domain.NewContainerClient(tenantId).ContainerApi.
 		GetContainerById(ctx, packageId, common.PackageContainerTypeName).
 		XCOREOSACCESS(token).
 		XCOREOSTID(tenantId).
-		XCOREOSREQUESTID(common.UUIDv4()).
-		XCOREOSUSERINFO("1234")
+		XCOREOSREQUESTID(requestId).
+		XCOREOSUSERINFO(userinfo)
 
 	d, r, e := domain.NewContainerClient(tenantId).ContainerApi.GetContainerByIdExecute(ApiGetContainerByIdRequest)
 
@@ -81,16 +84,18 @@ func (s Service) GetPackage(tenantId string, packageId string) (*api_v1.GetPacka
 
 }
 
-func (s Service) GetPackages(tenantId string) (*api_v1.GetPackagesResponse, error) {
+func (s Service) GetPackages(ctx context.Context) (*api_v1.GetPackagesResponse, error) {
+	tenantId := ctx.Value(common.ContextTenantId).(string)
+	token := ctx.Value(common.ContextMiddlewareAccessToken).(string)
+	requestId := ctx.Value(common.ContextRequestID).(string)
+	userinfo := ctx.Value(common.ContextUserinfo).(string)
 
-	token, _ := domain.GetToken(tenantId)
-	ctx := context.Background()
 	ApiGetContainersRequest := domain.NewContainerClient(tenantId).ContainerApi.
 		GetContainers(ctx, common.PackageContainerTypeName).
 		XCOREOSACCESS(token).
 		XCOREOSTID(tenantId).
-		XCOREOSREQUESTID(common.UUIDv4()).
-		XCOREOSUSERINFO("1234")
+		XCOREOSREQUESTID(requestId).
+		XCOREOSUSERINFO(userinfo)
 
 	d, r, e := domain.NewContainerClient(tenantId).ContainerApi.GetContainersExecute(ApiGetContainersRequest)
 
@@ -111,10 +116,11 @@ func (s Service) GetPackages(tenantId string) (*api_v1.GetPackagesResponse, erro
 
 }
 
-func (s Service) CreatePackage(tenantId string, request api_v1.CreatePackageJSONRequestBody) (*string, error) {
-
-	token, _ := domain.GetToken(tenantId)
-	ctx := context.Background()
+func (s Service) CreatePackage(ctx context.Context, request api_v1.CreatePackageJSONRequestBody) (*string, error) {
+	tenantId := ctx.Value(common.ContextTenantId).(string)
+	token := ctx.Value(common.ContextMiddlewareAccessToken).(string)
+	requestId := ctx.Value(common.ContextRequestID).(string)
+	userinfo := ctx.Value(common.ContextUserinfo).(string)
 
 	containerCreateRequest := containerdomain.ContainerCreateRequest{
 		ScannableId:       *request.ScannableId,
@@ -142,8 +148,8 @@ func (s Service) CreatePackage(tenantId string, request api_v1.CreatePackageJSON
 		XCOREOSACCESS(token).
 		XCOREOSORIGINTOKEN(token).
 		XCOREOSTID(tenantId).
-		XCOREOSREQUESTID(common.UUIDv4()).
-		XCOREOSUSERINFO("1234").
+		XCOREOSREQUESTID(requestId).
+		XCOREOSUSERINFO(userinfo).
 		ContainerCreateRequest(containerCreateRequest)
 
 	d, r, e := domain.NewContainerClient(tenantId).ContainerApi.CreateContainerExecute(ApiCreateContainerRequest)
@@ -163,10 +169,11 @@ func (s Service) CreatePackage(tenantId string, request api_v1.CreatePackageJSON
 
 // bag
 
-func (s Service) CreateBag(tenantId string, request api_v1.CreateBagJSONRequestBody) (*string, error) {
-
-	token, _ := domain.GetToken(tenantId)
-	ctx := context.Background()
+func (s Service) CreateBag(ctx context.Context, request api_v1.CreateBagJSONRequestBody) (*string, error) {
+	tenantId := ctx.Value(common.ContextTenantId).(string)
+	token := ctx.Value(common.ContextMiddlewareAccessToken).(string)
+	requestId := ctx.Value(common.ContextRequestID).(string)
+	userinfo := ctx.Value(common.ContextUserinfo).(string)
 
 	containerCreateRequest := containerdomain.ContainerCreateRequest{
 		ScannableId:       *request.ScannableId,
@@ -195,8 +202,8 @@ func (s Service) CreateBag(tenantId string, request api_v1.CreateBagJSONRequestB
 		XCOREOSACCESS(token).
 		XCOREOSORIGINTOKEN(token).
 		XCOREOSTID(tenantId).
-		XCOREOSREQUESTID(common.UUIDv4()).
-		XCOREOSUSERINFO("1234").
+		XCOREOSREQUESTID(requestId).
+		XCOREOSUSERINFO(userinfo).
 		ContainerCreateRequest(containerCreateRequest)
 
 	d, r, e := domain.NewContainerClient(tenantId).ContainerApi.CreateContainerExecute(ApiCreateContainerRequest)
@@ -213,15 +220,18 @@ func (s Service) CreateBag(tenantId string, request api_v1.CreateBagJSONRequestB
 	return nil, e
 }
 
-func (s Service) GetBag(tenantId string, bagId string) (*api_v1.GetBagResponse, error) {
-	token, _ := domain.GetToken(tenantId)
-	ctx := context.Background()
+func (s Service) GetBag(ctx context.Context, bagId string) (*api_v1.GetBagResponse, error) {
+	tenantId := ctx.Value(common.ContextTenantId).(string)
+	token := ctx.Value(common.ContextMiddlewareAccessToken).(string)
+	requestId := ctx.Value(common.ContextRequestID).(string)
+	userinfo := ctx.Value(common.ContextUserinfo).(string)
+
 	ApiGetContainerByIdRequest := domain.NewContainerClient(tenantId).ContainerApi.
 		GetContainerById(ctx, bagId, common.BagContainerTypeName).
 		XCOREOSACCESS(token).
 		XCOREOSTID(tenantId).
-		XCOREOSREQUESTID(common.UUIDv4()).
-		XCOREOSUSERINFO("1234")
+		XCOREOSREQUESTID(requestId).
+		XCOREOSUSERINFO(userinfo)
 
 	d, r, e := domain.NewContainerClient(tenantId).ContainerApi.GetContainerByIdExecute(ApiGetContainerByIdRequest)
 
@@ -241,16 +251,18 @@ func (s Service) GetBag(tenantId string, bagId string) (*api_v1.GetBagResponse, 
 
 }
 
-func (s Service) GetBags(tenantId string) (*api_v1.GetBagsResponse, error) {
+func (s Service) GetBags(ctx context.Context) (*api_v1.GetBagsResponse, error) {
+	tenantId := ctx.Value(common.ContextTenantId).(string)
+	token := ctx.Value(common.ContextMiddlewareAccessToken).(string)
+	requestId := ctx.Value(common.ContextRequestID).(string)
+	userinfo := ctx.Value(common.ContextUserinfo).(string)
 
-	token, _ := domain.GetToken(tenantId)
-	ctx := context.Background()
 	ApiGetContainersRequest := domain.NewContainerClient(tenantId).ContainerApi.
 		GetContainers(ctx, common.BagContainerTypeName).
 		XCOREOSACCESS(token).
 		XCOREOSTID(tenantId).
-		XCOREOSREQUESTID(common.UUIDv4()).
-		XCOREOSUSERINFO("1234")
+		XCOREOSREQUESTID(requestId).
+		XCOREOSUSERINFO(userinfo)
 
 	d, r, e := domain.NewContainerClient(tenantId).ContainerApi.GetContainersExecute(ApiGetContainersRequest)
 
@@ -273,7 +285,12 @@ func (s Service) GetBags(tenantId string) (*api_v1.GetBagsResponse, error) {
 }
 
 // container operations
-func (s Service) UpdateContainerState(tenantId string, containerId string, command string, containerTypeName string) error {
+func (s Service) UpdateContainerState(ctx context.Context, containerId string, command string, containerTypeName string) error {
+
+	tenantId := ctx.Value(common.ContextTenantId).(string)
+	token := ctx.Value(common.ContextMiddlewareAccessToken).(string)
+	requestId := ctx.Value(common.ContextRequestID).(string)
+	userinfo := ctx.Value(common.ContextUserinfo).(string)
 
 	var operation *common.ContainerStateOperation = nil
 
@@ -288,9 +305,6 @@ func (s Service) UpdateContainerState(tenantId string, containerId string, comma
 	} else {
 		return fmt.Errorf("Command %s is not supported", command)
 	}
-
-	token, _ := domain.GetToken(tenantId)
-	ctx := context.Background()
 
 	containerStateUpdateRequest := containerdomain.ContainerStateUpdateRequest{
 		EventCode:  operation.EventCode,
@@ -308,8 +322,8 @@ func (s Service) UpdateContainerState(tenantId string, containerId string, comma
 		UpdateContainerState(ctx, containerId, containerTypeName).
 		XCOREOSACCESS(token).
 		XCOREOSTID(tenantId).
-		XCOREOSREQUESTID(common.UUIDv4()).
-		XCOREOSUSERINFO("1234").
+		XCOREOSREQUESTID(requestId).
+		XCOREOSUSERINFO(userinfo).
 		ContainerStateUpdateRequest(containerStateUpdateRequest)
 
 	_, r, e := domain.NewContainerClient(tenantId).ContainerStateApi.UpdateContainerStateExecute(apiUpdateContainerStateRequest)
@@ -328,11 +342,11 @@ func (s Service) UpdateContainerState(tenantId string, containerId string, comma
 
 // containerize / decontainerize operations
 
-func (s Service) ContainerizeOperations(tenantId string, parentId string, containerId string, operation string) *api_v1.ErrorSchema {
-	glog.Info("parent: ", parentId)
-	glog.Info("child: ", containerId)
-	token, _ := domain.GetToken(tenantId)
-	ctx := context.Background()
+func (s Service) ContainerizeOperations(ctx context.Context, parentId string, containerId string, operation string) *api_v1.ErrorSchema {
+	tenantId := ctx.Value(common.ContextTenantId).(string)
+	token := ctx.Value(common.ContextMiddlewareAccessToken).(string)
+	requestId := ctx.Value(common.ContextRequestID).(string)
+	userinfo := ctx.Value(common.ContextUserinfo).(string)
 
 	ParentIdRequest := containerdomain.ParentIdRequest{
 		ParentId: parentId,
@@ -343,8 +357,8 @@ func (s Service) ContainerizeOperations(tenantId string, parentId string, contai
 		ContainerizeContainerById(ctx, containerId).
 		XCOREOSACCESS(token).
 		XCOREOSTID(tenantId).
-		XCOREOSREQUESTID(common.UUIDv4()).
-		XCOREOSUSERINFO("1234").
+		XCOREOSREQUESTID(requestId).
+		XCOREOSUSERINFO(userinfo).
 		ParentIdRequest(ParentIdRequest)
 
 	_, r, e := domain.NewContainerClient(tenantId).ContainerApi.ContainerizeContainerByIdExecute(apiContainerizeRequest)


### PR DESCRIPTION
- Introduce context-based mechanism for sharing common request attributes 
- Remove duplicate token invocation calls
- Use middleware to set userinfo object making the domain API calls 
- Remove tenant id params on domain service functions