### PR TITLE
Ability to toggle API authorization using env variables

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -5,3 +5,4 @@ APP_ID=platform:app:ContainerReferenceApp
 APP_CLIENT_ID=platform:app:ContainerReferenceApp-backend
 APP_CLIENT_SECRET=****
 APP_API_KEY=****
+AUTH_ENABLED=true

--- a/README.md
+++ b/README.md
@@ -39,7 +39,10 @@ openapi-codegen-client:
 
 ### Authorization
 
-There are two types of authorization supported by the service.
+Sample app provides authorization for the APIs by intercepting all the API requests using [gin middleware](https://gin-gonic.com/zh-tw/docs/examples/using-middleware/) and validating the authorization header. This process can be offloaded to the istio ingress interceptor while deploying the service into the CoreOS platform. While developing on the local machine or while deploying onto the CoreOS infrastructure, the service can be run without authorization by setting the `AUTH_ENABLED` environment variable to `false`.
+
+Sample app supports two types of authorization mechanisms when `AUTH_ENABLED` is set to `true`.
+
 - CoreOS token based authorization
 - API key based authorization
 

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -39,6 +39,13 @@ func Authorize(c *gin.Context) {
 	c.Set(common.ContextUserinfo, user)
 	c.Set(common.ContextRequestID, requestId)
 
+	// skip authorization if AUTH_ENABLED environment variable is set to false
+	if config.ServiceConf.APP.AuthEnabled == false {
+		glog.Info("App authorization is disabled")
+		c.Next()
+		return
+	}
+
 	if apiKey != "" {
 		if apiKey == config.ServiceConf.APP.ApiKey {
 			glog.Info("Valid API key")

--- a/configs/service.config.go
+++ b/configs/service.config.go
@@ -1,12 +1,15 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"strconv"
 )
 
 var (
-	ServiceConf *ServiceConfig //exported Configuration that all packages can use
+	ServiceConf    *ServiceConfig //exported Configuration that all packages can use
+	ErrEnvVarEmpty = errors.New("getenv: environment variable empty")
 )
 
 func LoadConfig() (*ServiceConfig, error) {
@@ -19,6 +22,7 @@ func LoadConfig() (*ServiceConfig, error) {
 		AppClientId     = "APP_CLIENT_ID"
 		AppClientSecret = "APP_CLIENT_SECRET"
 		AppApiKey       = "APP_API_KEY"
+		AuthEnabled     = "AUTH_ENABLED"
 	)
 
 	ServiceConf = &ServiceConfig{}
@@ -64,6 +68,12 @@ func LoadConfig() (*ServiceConfig, error) {
 		panic(fmt.Sprintf("Environment variable %s not set", AppApiKey))
 	}
 
+	if _, t := os.LookupEnv(AuthEnabled); t {
+		ServiceConf.APP.AuthEnabled, _ = strconv.ParseBool(os.Getenv(AuthEnabled))
+	} else {
+		panic(fmt.Sprintf("Environment variable %s not set", AuthEnabled))
+	}
+
 	// TODO: use viper to mape enviornment variables/ config yaml to ServiceConf
 	return ServiceConf, nil
 }
@@ -80,4 +90,5 @@ type app struct {
 	ClientId     string
 	ClientSecret string
 	ApiKey       string
+	AuthEnabled  bool
 }


### PR DESCRIPTION
- Added ability to toggle API authorization using AUTH_ENABLED environment variable 
- When AUTH_ENABLED flag is turned off, the service will skip API key or CoreOS token authorization 
- Updated Readme